### PR TITLE
fix: docker image naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Orkes Conductor is a fully compatible version of Netflix Conductor with **Orkes 
 
 ## Getting Started
 ### Docker
-Easiest way to run Conductor.  Each release is published as `orkes-io/orkes-conductor-community` docker images. 
+Easiest way to run Conductor.  Each release is published as `orkesio/orkes-conductor-community` docker images.
 
 #### Fully self-contained standalone server with all the dependencies
 Container image useful for local development and testing.  
@@ -64,7 +64,7 @@ docker pull orkesio/orkes-conductor-community:latest
 >**Note** To use specific version of Conductor, replace `latest` with the release version
 > e.g. 
 > 
-> ```docker pull orkes-io/orkes-conductor-community:latest```
+> ```docker pull orkesio/orkes-conductor-community:latest```
 
 ### Published Artifacts
 

--- a/scripts/run_local.sh
+++ b/scripts/run_local.sh
@@ -21,7 +21,7 @@ docker volume create postgres
 docker volume create redis
 
 docker run --init -p $SERVER_PORT:8080 -p $UI_PORT:5000 --mount source=redis,target=/redis \
---mount source=postgres,target=/pgdata orkesio/orkes-conductor-standalone:latest
+--mount source=postgres,target=/pgdata orkesio/orkes-conductor-community-standalone:latest
 
 
 


### PR DESCRIPTION
docker image naming does not match with what is available in [docker-hub](https://hub.docker.com/search?q=orkes-conductor-community)

how to reproduce the Error:
```
curl https://raw.githubusercontent.com/orkes-io/orkes-conductor-community/main/scripts/run_local.sh | sh
```
Output:
```
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   546  100   546    0     0    802      0 --:--:-- --:--:-- --:--:--   801
Enter the port for UI [1234]:
Enter the port for Server [8080]:
postgres
redis
Unable to find image 'orkesio/orkes-conductor-standalone:latest' locally
docker: Error response from daemon: pull access denied for orkesio/orkes-conductor-standalone, repository does not exist or may require 'docker login': denied: requested access to the resource is denied.
See 'docker run --help'.
```