### PR TITLE
Expose actuator metrics through nginx server

### DIFF
--- a/docker/config/nginx.conf
+++ b/docker/config/nginx.conf
@@ -29,6 +29,17 @@ server {
     proxy_cache_bypass $http_upgrade;
     proxy_redirect off;
   }
+  
+  location /actuator {
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-NginX-Proxy true;
+    proxy_pass http://localhost:8080/actuator;
+    proxy_ssl_session_reuse off;
+    proxy_set_header Host $http_host;
+    proxy_cache_bypass $http_upgrade;
+    proxy_redirect off;
+  }
 
   location /swagger-ui {
     proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
On enabling prometheus metrics the `/actuator/prometheus` path is redirected to the UI itself because of the nginx rule. This will expose the actuator routes (health,info,prom) to the user