### PR TITLE
Wait task test update and swagger fixes

### DIFF
--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -78,5 +78,5 @@ springdoc.swagger-ui.disable-swagger-default-url=true
 springdoc.swagger-ui.queryConfigEnabled=false
 springdoc.swagger-ui.filter=true
 
-conductor.swagger.url=http://localhost:8080/
+conductor.swagger.url=/
 

--- a/test-harness/src/test/java/io/orkes/conductor/client/e2e/WaitTaskTest.java
+++ b/test-harness/src/test/java/io/orkes/conductor/client/e2e/WaitTaskTest.java
@@ -47,8 +47,8 @@ public class WaitTaskTest extends AbstractConductorTest {
         assertEquals(Workflow.WorkflowStatus.COMPLETED, run.getStatus());
         assertEquals(1, run.getTasks().size());
         long timeToExecute = run.getTasks().get(0).getEndTime() - run.getTasks().get(0).getScheduledTime();
-
+        System.out.println("Wait task completed in " + timeToExecute + " millis - should have completed in around 2 second mark");
         // Ensure the wait completes within 1sec buffer
-        assertTrue(timeToExecute < 31000, "Wait task did not complete in time, took " + timeToExecute + " millis");
+        assertTrue(timeToExecute < 3000, "Wait task did not complete in time, took " + timeToExecute + " millis");
     }
 }


### PR DESCRIPTION
* Add a test to validate that the wait completes in less than 30 sec
* Updated the swagger URL for server not running on port 8080